### PR TITLE
Add `outputs.pushed` to `commit-and-push` action

### DIFF
--- a/commit-and-push/action.yml
+++ b/commit-and-push/action.yml
@@ -4,6 +4,11 @@ description: >
   Creates a new commit with current changes and push them
   to the selected branch using the GitHub Actions user
 
+outputs:
+  pushed:
+    description: Whether changes were pushed to the remote repository
+    value: ${{ steps.commit-and-push.outputs.pushed }}
+
 inputs:
   branch:
     description: >
@@ -27,6 +32,7 @@ runs:
   using: composite
   steps:
     - name: Create commit with current changes and push it to ${{ inputs.branch }}
+      id: commit-and-push
       shell: bash
       run: ${{ github.action_path }}/commit-and-push.sh
       env:

--- a/commit-and-push/commit-and-push.sh
+++ b/commit-and-push/commit-and-push.sh
@@ -21,6 +21,8 @@ if [ -n "$(git status -s)" ]; then
     fi
 
     echo "🚀 Changes have been pushed to branch $GIT_BRANCH"
+    echo "pushed=true" >> "$GITHUB_OUTPUT"
 else
     echo "🧺 Working tree clean. Nothing to commit."
+    echo "pushed=false" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
## Summary

- Adds a new `pushed` output to the `commit-and-push` action that indicates whether changes were actually pushed to the remote repository
- Returns `true` when changes are committed and pushed, `false` when the working tree is clean

Closes #11