### PR TITLE
fix regex; Support -RC suffix

### DIFF
--- a/check-semver-tag/check-semver-tag.sh
+++ b/check-semver-tag/check-semver-tag.sh
@@ -1,4 +1,4 @@
-if [[ $TAG =~ ^(refs/tags/)?v[0-9]+\.[0-9]+\.[0-9]+(-M\d+)?$ ]]; then
+if [[ $TAG =~ ^(refs/tags/)?v[0-9]+\.[0-9]+\.[0-9]+(-(M|RC)[0-9]+)?$ ]]; then
     echo "🏷 $TAG follows semver"
 else
     echo "::error ::Tag $TAG does not follow semver"


### PR DESCRIPTION
This PR:

1. Adds support for `-RC{n}` suffixes.
2. Fixes suffix expression where `=~` expects POSIX ERE but `\d` is Perl PCRE syntax 